### PR TITLE
fix: added origin base url to support full origin (https://)

### DIFF
--- a/utils/base.ts
+++ b/utils/base.ts
@@ -1,3 +1,3 @@
 export const getBaseUrl = () => {
-    return location.host;
+    return location.origin;
 };


### PR DESCRIPTION
I liked the counter idea, but in order for it to work on my profile, I needed to include the full absolute URL with https://.

The copy and paste on https://counter.vifu.org/ currently generates:

```
![counter](counter.vifu.org/api/count?type=github-profile&input=flipthedog&badge=true&badgeContent=Views&badgeLabelColor=%234b9834&badgeColor=%23ffffff&badgeStyle=flat)
```

when it should be:

```
![counter](https://counter.vifu.org/api/count?type=github-profile&input=flipthedog&badge=true&badgeContent=Views&badgeLabelColor=%234b9834&badgeColor=%23ffffff&badgeStyle=flat)
```

I didn't see any contribution guidelines or branches, so I hope this is okay.